### PR TITLE
(LYR-159) Use Resource annotation's provided_attributes when comparing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ require (
 	github.com/hashicorp/go-hclog v0.0.0-20181001195459-61d530d6c27f
 	github.com/lyraproj/hiera v0.0.0-20181209022223-4ffb7c3f8587
 	github.com/lyraproj/issue v0.0.0-20181208172701-8d203563a8dc
-	github.com/lyraproj/puppet-evaluator v0.0.0-20181219140551-7a196a921fba
+	github.com/lyraproj/puppet-evaluator v0.0.0-20181221111050-0504504a3bd1
 	github.com/lyraproj/puppet-parser v0.0.0-20181212205830-31c3104fe78d
 	github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2
-	github.com/lyraproj/servicesdk v0.0.0-20181219142950-09bc8fc747de
+	github.com/lyraproj/servicesdk v0.0.0-20181221120918-004634e337ed
 	gonum.org/v1/gonum v0.0.0-20181216103746-44a6721e0d61
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,9 @@ github.com/lyraproj/puppet-evaluator v0.0.0-20181217152942-a88a4196d4f1 h1:/aLjb
 github.com/lyraproj/puppet-evaluator v0.0.0-20181217152942-a88a4196d4f1/go.mod h1:zzujLCRGe29CXjx2PYphNjYQAnasgzsz+np2ww6d3Mo=
 github.com/lyraproj/puppet-evaluator v0.0.0-20181219140551-7a196a921fba h1:ukyLkjSEz5uVTXiav8g97U2OzLFi8bH67tMwCFeACB8=
 github.com/lyraproj/puppet-evaluator v0.0.0-20181219140551-7a196a921fba/go.mod h1:zzujLCRGe29CXjx2PYphNjYQAnasgzsz+np2ww6d3Mo=
+github.com/lyraproj/puppet-evaluator v0.0.0-20181220110523-c35808ba183f h1:4PtexUpCiaXmH4+e6+xxcCfK4ItsNBnpLGuSI/rFJKg=
+github.com/lyraproj/puppet-evaluator v0.0.0-20181221111050-0504504a3bd1 h1:H+lZQzoL0/2CgaCNo7YcSWI86jzqSd3LY/TAcvvNAf4=
+github.com/lyraproj/puppet-evaluator v0.0.0-20181221111050-0504504a3bd1/go.mod h1:zzujLCRGe29CXjx2PYphNjYQAnasgzsz+np2ww6d3Mo=
 github.com/lyraproj/puppet-parser v0.0.0-20181204211711-c9870a9ba412/go.mod h1:8va5g/XEw+jP9jnwEXPmanUy/hD9+6iggnaioihPLP0=
 github.com/lyraproj/puppet-parser v0.0.0-20181212205830-31c3104fe78d h1:iDn6XlJAiA+BuwG6L8xsCapPpc7jz24SGj9z7NQA1sg=
 github.com/lyraproj/puppet-parser v0.0.0-20181212205830-31c3104fe78d/go.mod h1:8va5g/XEw+jP9jnwEXPmanUy/hD9+6iggnaioihPLP0=
@@ -35,6 +38,9 @@ github.com/lyraproj/servicesdk v0.0.0-20181217152923-a34b842a6c63 h1:IPX2LY0Nhkr
 github.com/lyraproj/servicesdk v0.0.0-20181217152923-a34b842a6c63/go.mod h1:4OKpXDuJ/3mZ6d5tZvCk0p62Vay9Um5V+vOMXHRXYuM=
 github.com/lyraproj/servicesdk v0.0.0-20181219142950-09bc8fc747de h1:wHFd9wdPWGDVzQ3h6QhdtxFtTwuPXkAFwYGoF2PZ5uw=
 github.com/lyraproj/servicesdk v0.0.0-20181219142950-09bc8fc747de/go.mod h1:UxAOgMidVQrg8Q7YB1nrShsfbBZwTIq5ED9aamLSStg=
+github.com/lyraproj/servicesdk v0.0.0-20181219151107-1fe42a9bc57c h1:ck+W3N4YkWdttJ5SFkzaMy6dbNO31mjAinYeiZx4R6Y=
+github.com/lyraproj/servicesdk v0.0.0-20181221120918-004634e337ed h1:ihTEeEIQLuY1HBO/EuuTHK2FuMfWFMVQ162Z3RQsJX0=
+github.com/lyraproj/servicesdk v0.0.0-20181221120918-004634e337ed/go.mod h1:rXVWEj4jy+QCF6T5++mU4NyxlNPPNLLkrMDE4jXjxnU=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -43,6 +49,7 @@ golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181217023233-e147a9138326/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
This commit replaces the temporary solution, using attribute kind
`given_or_derived` to exclude attributes when comparing desired and
actual state, with a mechanism that excludes the attributes based on
the `provided_attributes` array in a `Resource` annotation.