### PR TITLE
Defer resource deletion until garbage collection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/hashicorp/go-hclog v0.8.0
 	github.com/kisielk/gotool v1.0.0 // indirect
 	github.com/lyraproj/issue v0.0.0-20190213110846-64f0e861a560
-	github.com/lyraproj/servicesdk v0.0.0-20190313114433-a66d98e28e69 // indirect
+	github.com/lyraproj/pcore v0.0.0-20190313112821-30e7bb7af627
+	github.com/lyraproj/servicesdk v0.0.0-20190313114433-a66d98e28e69
 	gonum.org/v1/gonum v0.0.0-20190312022028-60a68a3a7f2c
 )

--- a/service/crud.go
+++ b/service/crud.go
@@ -106,7 +106,7 @@ func ApplyState(c px.Context, resource api.Resource, input px.OrderedMap) px.Ord
 				}
 			}
 
-			handler.Invoke(c, hn, `delete`, extId)
+			// Rely on that deletion happens by means of GC at end of run
 			identity.removeExternal(c, extId)
 
 			rt := handler.Invoke(c, hn, `create`, desiredState)


### PR DESCRIPTION
This commit removes the explicit delete call that might happen during
upsert of a resource. The resource will instead be deleted by means of
garbage collection at the end of the run.

closes lyraproj/lyra#160