### PR TITLE
Ensure that workflow activities that ends with panic are recovered

### DIFF
--- a/api/issues.go
+++ b/api/issues.go
@@ -6,6 +6,7 @@ const (
 	NoSuchAttribute             = `WF_NO_SUCH_ATTRIBUTE`
 	NoActivityContext           = `WF_NO_ACTIVITY_CONTEXT`
 	MissingRequiredProperty     = `WF_MISSING_REQUIRED_PROPERTY`
+	MultipleErrors              = `WF_MULTIPLE_ERRORS`
 	UnableToLoadRequired        = `WF_UNABLE_TO_LOAD_REQUIRED`
 	UnableToDetermineExternalId = `WF_UNABLE_TO_DETERMINE_EXTERNAL_ID`
 )
@@ -14,6 +15,7 @@ func init() {
 	issue.Hard2(NoSuchAttribute, `%{activity} has no attribute named '%{name}'`, issue.HF{`activity`: issue.Label})
 	issue.Hard(NoActivityContext, `no activity context was found in current scope`)
 	issue.Hard(MissingRequiredProperty, `definition %{service} %{definition} is missing required property '%{key}'`)
+	issue.Hard2(MultipleErrors, `multiple errors: %{errors}`, issue.HF{`errors`: issue.JoinErrors})
 	issue.Hard(UnableToLoadRequired, `unable to load required %{namespace} '%{name}'`)
 	issue.Hard(UnableToDetermineExternalId, `unable to determine external ID for %{style} '%{id}'`)
 }

--- a/wfe/workflowengine.go
+++ b/wfe/workflowengine.go
@@ -2,6 +2,7 @@ package wfe
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -81,6 +82,7 @@ type workflowEngine struct {
 	jobCounter   int32
 	done         chan bool
 	graph        *simple.DirectedGraph
+	errors       []error
 }
 
 func NewWorkflowEngine(workflow api.Workflow) WorkflowEngine {
@@ -324,6 +326,16 @@ func (s *workflowEngine) Run(ctx px.Context, input px.OrderedMap) px.OrderedMap 
 	}
 	<-s.done
 
+	if s.errors != nil {
+		var err error
+		if len(s.errors) == 1 {
+			err = s.errors[0]
+		} else {
+			err = px.Error(api.MultipleErrors, issue.H{`errors`: s.errors})
+		}
+		panic(err)
+	}
+
 	entries := make([]*types.HashEntry, len(s.Output()))
 	for i, out := range s.Output() {
 		n := out.Name()
@@ -389,14 +401,49 @@ nextName:
 func (s *workflowEngine) activityWorker(ctx px.Context, id int) {
 	for a := range s.inbox {
 		s.runActivity(ctx, a)
-		if atomic.AddInt32(&s.jobCounter, -1) <= 0 {
-			close(s.inbox)
-			close(s.done)
-		}
 	}
 }
 
 func (s *workflowEngine) runActivity(ctx px.Context, a *serverActivity) {
+	defer func() {
+		r := recover()
+		if r != nil {
+			var err error
+			switch r := r.(type) {
+			case error:
+				err = r
+			case string:
+				err = errors.New(r)
+			case fmt.Stringer:
+				err = errors.New(r.String())
+			default:
+				err = fmt.Errorf("%v", r)
+			}
+			s.valuesLock.Lock()
+			if s.errors == nil {
+				s.errors = []error{err}
+			} else {
+				s.errors = append(s.errors, err)
+			}
+		}
+		if atomic.AddInt32(&s.jobCounter, -1) <= 0 || r != nil {
+			// Close inbox and done. Need to catch panics for when close is issued on an
+			// already closed channel since multiple routines might encounter errors
+			func() {
+				defer func() {
+					recover()
+				}()
+				close(s.inbox)
+			}()
+			func() {
+				defer func() {
+					recover()
+				}()
+				close(s.done)
+			}()
+		}
+	}()
+
 	s.runLatchLock.Lock()
 	if s.runLatch[a.ID()] {
 		s.runLatchLock.Unlock()


### PR DESCRIPTION
This commit ensures that the execution of a workflow activity that
terminates abnormally is recovered and then rethrown by the workflow's
Go routine.

Relates to lyraproj/lyra#134