### PR TITLE
Ensure that handler is loaded before resolve of resource type

### DIFF
--- a/wfe/activity.go
+++ b/wfe/activity.go
@@ -24,18 +24,18 @@ type Activity struct {
 	output    []px.Parameter
 }
 
-func CreateActivity(def serviceapi.Definition) api.Activity {
+func CreateActivity(c px.Context, def serviceapi.Definition) api.Activity {
 	hclog.Default().Debug(`creating activity`, `style`, service.GetStringProperty(def, `style`))
 
 	switch service.GetStringProperty(def, `style`) {
 	case `stateHandler`:
 		return StateHandler(def)
 	case `iterator`:
-		return Iterator(def)
+		return Iterator(c, def)
 	case `resource`:
-		return Resource(def)
+		return Resource(c, def)
 	case `workflow`:
-		return Workflow(def)
+		return Workflow(c, def)
 	case `action`:
 		return Action(def)
 	}

--- a/wfe/iterator.go
+++ b/wfe/iterator.go
@@ -22,11 +22,11 @@ type iterator struct {
 	resultName string
 }
 
-func Iterator(def serviceapi.Definition) api.Activity {
+func Iterator(c px.Context, def serviceapi.Definition) api.Activity {
 	over := getParameters(`over`, def.Properties())
 	variables := getParameters(`variables`, def.Properties())
 	style := wf.NewIterationStyle(service.GetStringProperty(def, `iterationStyle`))
-	activity := CreateActivity(service.GetProperty(def, `producer`, serviceapi.DefinitionMetaType).(serviceapi.Definition))
+	activity := CreateActivity(c, service.GetProperty(def, `producer`, serviceapi.DefinitionMetaType).(serviceapi.Definition))
 	resultName := wf.LeafName(def.Identifier().Name())
 	switch style {
 	case wf.IterationStyleRange:

--- a/wfe/workflow.go
+++ b/wfe/workflow.go
@@ -30,20 +30,16 @@ func (w *workflow) Style() string {
 	return `workflow`
 }
 
-func Workflow(def serviceapi.Definition) api.Workflow {
+func Workflow(c px.Context, def serviceapi.Definition) api.Workflow {
 	wf := &workflow{}
 	wf.Init(def)
+	activities := service.GetProperty(def, `activities`, DefinitionListType).(px.List)
+	as := make([]api.Activity, activities.Len())
+	activities.EachWithIndex(func(v px.Value, i int) { as[i] = CreateActivity(c, v.(serviceapi.Definition)) })
+	wf.activities = as
 	return wf
 }
 
 func (w *workflow) Activities() []api.Activity {
 	return w.activities
-}
-
-func (w *workflow) Init(def serviceapi.Definition) {
-	w.Activity.Init(def)
-	activities := service.GetProperty(def, `activities`, DefinitionListType).(px.List)
-	as := make([]api.Activity, activities.Len())
-	activities.EachWithIndex(func(v px.Value, i int) { as[i] = CreateActivity(v.(serviceapi.Definition)) })
-	w.activities = as
 }


### PR DESCRIPTION
This commit ensures that an unresolved resource type in a definition
is resolved only after the handler for that type has been loaded.
Failing to do so means that the type cannot be resolved.