### PR TITLE
Add ability to debug loaded plugin processes

### DIFF
--- a/api/loader.go
+++ b/api/loader.go
@@ -6,3 +6,5 @@ var LyraLinkPath = px.PathType(`lyralink`)
 var GoPluginPath = px.PathType(`goplugin`)
 var PpManifestPath = px.PathType(`ppmanifest`)
 var YamlManifestPath = px.PathType(`yamlmanifest`)
+
+const LyraDlvConfigKey = `Lyra::DlvConfig`


### PR DESCRIPTION
Checks if the provided px.Context contains a 'Lyra::DlvConfig' and if
so, uses that config to configure the loader to start plugins appointed
by that config in debug mode.