### PR TITLE
Treat NotFound as obsolete external id.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/lyraproj/wfe
 require (
 	github.com/hashicorp/go-hclog v0.8.0
 	github.com/lyraproj/issue v0.0.0-20190329160035-8bc10230f995
-	github.com/lyraproj/pcore v0.0.0-20190430133451-57d4da316569
-	github.com/lyraproj/servicesdk v0.0.0-20190430133733-68a5a13f9111
+	github.com/lyraproj/pcore v0.0.0-20190502085713-c95bdae56d68
+	github.com/lyraproj/servicesdk v0.0.0-20190507143352-f65d30892e58
 	gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485
 )

--- a/go.sum
+++ b/go.sum
@@ -23,10 +23,15 @@ github.com/lyraproj/issue v0.0.0-20190329160035-8bc10230f995 h1:vAlBUcYalN98yypS
 github.com/lyraproj/issue v0.0.0-20190329160035-8bc10230f995/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
 github.com/lyraproj/pcore v0.0.0-20190430133451-57d4da316569 h1:wzY8l1Rkl5UIwq7/2U56Mi2RkFjzChTTXzAnW311zTE=
 github.com/lyraproj/pcore v0.0.0-20190430133451-57d4da316569/go.mod h1:rEl2ewvqyi/MUo+sEoADKduVlO971HgiLJmu26EO+vM=
+github.com/lyraproj/pcore v0.0.0-20190502085713-c95bdae56d68 h1:/sZhuQeebUbpjuHL9EZCMBn0OJoHrR7okfYD0pnvlTI=
+github.com/lyraproj/pcore v0.0.0-20190502085713-c95bdae56d68/go.mod h1:rEl2ewvqyi/MUo+sEoADKduVlO971HgiLJmu26EO+vM=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
 github.com/lyraproj/servicesdk v0.0.0-20190430133733-68a5a13f9111 h1:1ldNNnnK/Rb2myLgSk/hE/4TV8BOUzmGw+on4RV2Dl8=
 github.com/lyraproj/servicesdk v0.0.0-20190430133733-68a5a13f9111/go.mod h1:EmDPNtYrtPyWgOAIri33u3ARX8LQH4Iccfqf4KiqTnM=
+github.com/lyraproj/servicesdk v0.0.0-20190507133311-974f5eac5047 h1:d4M4hks22aoBQFksLf0JxphUftza917OJ2c9AYlp/5M=
+github.com/lyraproj/servicesdk v0.0.0-20190507143352-f65d30892e58 h1:3YPc4x0hy0wnecq2VqIzRb28Kzx5AGiB7UPKRN/I32g=
+github.com/lyraproj/servicesdk v0.0.0-20190507143352-f65d30892e58/go.mod h1:mAgzNVtNRt2DltU6NACk6bGvKyoEwcbgfhuQWkIYoIU=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 h1:7GoSOOW2jpsfkntVKaS2rAr1TJqfcxotyaUcuxoZSzg=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=


### PR DESCRIPTION
If a plug-in responds to a read request with a NotFound error, then
treat that as if the external ID used in the request is obsolete and
purge it from the Identity service.

Closes lyraproj/lyra#214