### PR TITLE
Fix regression causing failure to catch NotFound error

### DIFF
--- a/service/crud.go
+++ b/service/crud.go
@@ -8,7 +8,6 @@ import (
 	"github.com/lyraproj/pcore/px"
 	"github.com/lyraproj/pcore/types"
 	"github.com/lyraproj/servicesdk/annotation"
-	"github.com/lyraproj/servicesdk/grpc"
 	"github.com/lyraproj/servicesdk/service"
 	"github.com/lyraproj/servicesdk/serviceapi"
 	"github.com/lyraproj/servicesdk/wf"
@@ -55,13 +54,11 @@ func SweepAndGC(c px.Context, prefix string) {
 func readOrNotFound(c px.Context, handler serviceapi.Service, hn string, extId px.Value, identity *identity) px.Value {
 	defer func() {
 		if r := recover(); r != nil {
-			if e, ok := r.(issue.Reported); ok && e.Code() == grpc.InvocationError {
-				if e.Argument(`code`) == service.NotFound {
-					// Not found by remote. Purge the extId and return nil.
-					hclog.Default().Debug("Removing obsolete extId from Identity service", "extId", extId)
-					identity.purgeExternal(c, extId)
-					return
-				}
+			if e, ok := r.(issue.Reported); ok && e.Code() == service.NotFound {
+				// Not found by remote. Purge the extId and return nil.
+				hclog.Default().Debug("Removing obsolete extId from Identity service", "extId", extId)
+				identity.purgeExternal(c, extId)
+				return
 			}
 			panic(r)
 		}


### PR DESCRIPTION
The logic catching the NotFound error from a provider no longer worked
due to the improved error handling where the grpc.InvocationError was
stripped (it is only used for propagation of the actual error).

This commit changes the logic to look directly for the actual error.