### PR TITLE
Ensure that parameters are evaluated using a parameter scope

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/lyraproj/wfe
 require (
 	github.com/hashicorp/go-hclog v0.8.0
 	github.com/lyraproj/issue v0.0.0-20190513084509-faf9b542f594
-	github.com/lyraproj/pcore v0.0.0-20190516164225-2c1838ece043
-	github.com/lyraproj/servicesdk v0.0.0-20190517131335-c9b92d064792
+	github.com/lyraproj/pcore v0.0.0-20190522151013-7e0d4b53ab56
+	github.com/lyraproj/servicesdk v0.0.0-20190522152908-2de3fa2afbc0
 	gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485
 )

--- a/go.sum
+++ b/go.sum
@@ -21,12 +21,12 @@ github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b h1:qGgMkFUQ
 github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b/go.mod h1:oQIFBu0fmkiSpSRROEgK5gnjQ/ZDrx3UdpRpT3791Gg=
 github.com/lyraproj/issue v0.0.0-20190513084509-faf9b542f594 h1:IcsHRQ3xzCIcK0eXpot8IYgEyUQPEFHmFErZwJcsDqk=
 github.com/lyraproj/issue v0.0.0-20190513084509-faf9b542f594/go.mod h1:jqRRmAiVqjTehhncbKJPoC2AFoxxkritzzlfWioTa00=
-github.com/lyraproj/pcore v0.0.0-20190516164225-2c1838ece043 h1:tSLm3r+Z+ej4kyaXn7/okyw8sHkjE5LKZ1dNqA1gpVM=
-github.com/lyraproj/pcore v0.0.0-20190516164225-2c1838ece043/go.mod h1:NEsDhoJnhU6dqrNy3M2W4AWryrwPhADubXu6RWVdAl4=
+github.com/lyraproj/pcore v0.0.0-20190522151013-7e0d4b53ab56 h1:fj8bSDDwaZJpVjLkzv1dEKiShGgOvuusLeHU1asw55c=
+github.com/lyraproj/pcore v0.0.0-20190522151013-7e0d4b53ab56/go.mod h1:NEsDhoJnhU6dqrNy3M2W4AWryrwPhADubXu6RWVdAl4=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
-github.com/lyraproj/servicesdk v0.0.0-20190517131335-c9b92d064792 h1:C4qmB2/Y/70SmB+3MLxZImhp0oPI+ta/WiAI7WbK5q4=
-github.com/lyraproj/servicesdk v0.0.0-20190517131335-c9b92d064792/go.mod h1:oRnxP9zeUPRbbQ1i+b1uKKrkzq2qhNcOLID9/Kl1AMM=
+github.com/lyraproj/servicesdk v0.0.0-20190522152908-2de3fa2afbc0 h1:stEYYJm8oaxOGXqXm/oWyEBKeGL8nHF66qG9qdf7HUM=
+github.com/lyraproj/servicesdk v0.0.0-20190522152908-2de3fa2afbc0/go.mod h1:Nq1sebIncObh30yrQzVZOE/q58I2opu6ceNOecSYqiw=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 h1:7GoSOOW2jpsfkntVKaS2rAr1TJqfcxotyaUcuxoZSzg=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=


### PR DESCRIPTION
All parameters must be evaluated with knowledge of previously evaluated
parameter so that one parameter value can reference parameters that have
already been evaluated. This means that all evaluated parameters are
added to a special scope that is then used during the evaluation of
the remaining parameters.