### PR TITLE
Follow change in servicesdk and unwrap Invocation error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/lyraproj/servicesdk v0.0.0-20190604154336-99ba85971af2
 	gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485
 )
+
+replace github.com/lyraproj/servicesdk => github.com/thallgren/servicesdk v0.0.0-20190606103012-855113341667

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/thallgren/servicesdk v0.0.0-20190606103012-855113341667 h1:J5yVvEIzOI5EcuHlAqfS+RuTidMe9YxicF/RyApregI=
+github.com/thallgren/servicesdk v0.0.0-20190606103012-855113341667/go.mod h1:+IR74NuJQyJnnRUUrtp44Lu5Iu950oAwW0oSs2isvXI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2 h1:y102fOLFqhV41b+4GPiJoa0k/x+pJcEi2/HB1Y5T6fU=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/service/crud.go
+++ b/service/crud.go
@@ -54,11 +54,13 @@ func SweepAndGC(c px.Context, prefix string) {
 func readOrNotFound(c px.Context, handler serviceapi.Service, hn string, extId px.Value, identity *identity) px.Value {
 	defer func() {
 		if r := recover(); r != nil {
-			if e, ok := r.(issue.Reported); ok && e.Code() == service.NotFound {
-				// Not found by remote. Purge the extId and return nil.
-				hclog.Default().Debug("Removing obsolete extId from Identity service", "extId", extId)
-				identity.purgeExternal(c, extId)
-				return
+			if e, ok := r.(issue.Reported); ok {
+				if e, ok = e.Cause().(issue.Reported); ok && e.Code() == service.NotFound {
+					// Not found by remote. Purge the extId and return nil.
+					hclog.Default().Debug("Removing obsolete extId from Identity service", "extId", extId)
+					identity.purgeExternal(c, extId)
+					return
+				}
 			}
 			panic(r)
 		}


### PR DESCRIPTION
The new design of passing errors over grpc in order to reporting host
and executable means that the service.NotFound error is now a cause
found inside the wrapper. This commit ensures that it is unwrapped and
dealt with.

This PR should be merged together with lyraproj/servicesdk#41