### PR TITLE
Fix glitch preventing return values from being assembled

### DIFF
--- a/wfe/workflowengine.go
+++ b/wfe/workflowengine.go
@@ -282,6 +282,9 @@ func (vp valueProducers) validate(a api.Step) {
 		}
 	}
 	for _, param := range a.Returns() {
+		if param.Value() != nil {
+			continue
+		}
 		if _, found := vp[param.Name()]; found {
 			continue
 		}


### PR DESCRIPTION
This commit ensures that a return value can have a literal value that
can be assembled from known variables. E.g.

    returns:
      info:
        value:
          name: $name
          age: $age