### PR TITLE
Add a LazyIdentity type

### DIFF
--- a/service/crud.go
+++ b/service/crud.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"strings"
+	"sync"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/lyraproj/issue/issue"
@@ -14,22 +15,73 @@ import (
 	"github.com/lyraproj/wfe/api"
 )
 
-func StartEra(c px.Context) {
-	getIdentity(c).bumpEra(c)
+type commandType int
+
+const (
+	startEra = commandType(iota)
+
+	gcKey = `Lyra::Deferred::IdentityService`
+)
+
+type command struct {
+	t commandType
+}
+
+func (cmd *command) apply(c px.Context, is *identity) {
+	switch cmd.t {
+	case startEra:
+		is.bumpEra(c)
+	}
+}
+
+type LazyIdentity struct {
+	deferredCommands []*command
+	service          *identity
+}
+
+var liLock sync.Mutex
+
+func GetLazyIdentity(c px.Context) (li *LazyIdentity) {
+	liLock.Lock()
+	if v, ok := c.Get(gcKey); ok {
+		li = v.(*LazyIdentity)
+	} else {
+		li = &LazyIdentity{}
+		c.Set(gcKey, li)
+	}
+	liLock.Unlock()
+	return
+}
+
+func (gc *LazyIdentity) StartEra(c px.Context) {
+	if gc.service == nil {
+		gc.deferredCommands = append(gc.deferredCommands, &command{startEra})
+	} else {
+		gc.service.bumpEra(c)
+	}
+}
+
+// LazySweepAndGC calls SweepAndGC if there has been any activity detected since
+// the instance was obtained. Bumping the era is not considered an activity
+func (gc *LazyIdentity) LazySweepAndGC(c px.Context, prefix string) {
+	if gc.service == nil {
+		return
+	}
+	gc.SweepAndGC(c, prefix)
 }
 
 // SweepAndGC performs a sweep of the Identity store, retrieves all garbage, and
 // then tells the handler for each garbage entry to delete the resource. The entry
 // is then purged from the Identity store
-func SweepAndGC(c px.Context, prefix string) {
-	identity := getIdentity(c)
+func (gc *LazyIdentity) SweepAndGC(c px.Context, prefix string) {
+	identity := gc.getIdentity(c)
 	log := hclog.Default()
-	log.Debug("GC Sweep", "prefix", prefix)
+	log.Debug("LazyIdentity Sweep", "prefix", prefix)
 	identity.sweep(c, prefix)
-	log.Debug("GC Collect garbage", "prefix", prefix)
+	log.Debug("LazyIdentity Collect garbage", "prefix", prefix)
 	gl := identity.garbage(c, prefix)
 	ng := gl.Len()
-	log.Debug("GC Collect garbage", "prefix", prefix, "count", ng)
+	log.Debug("LazyIdentity Collect garbage", "prefix", prefix, "count", ng)
 	rs := make([]px.List, ng)
 
 	// Store in reverse order
@@ -45,20 +97,32 @@ func SweepAndGC(c px.Context, prefix string) {
 		handler := GetService(c, handlerDef.ServiceId())
 
 		extId := l.At(1)
-		log.Debug("GC delete", "prefix", prefix, "intId", uri.String(), "extId", extId)
+		log.Debug("LazyIdentity delete", "prefix", prefix, "intId", uri.String(), "extId", extId)
 		handler.Invoke(c, handlerDef.Identifier().Name(), `delete`, extId)
 		identity.purgeExternal(c, extId)
 	}
 }
 
-func readOrNotFound(c px.Context, handler serviceapi.Service, hn string, extId px.Value, identity *identity) px.Value {
+func (gc *LazyIdentity) getIdentity(c px.Context) *identity {
+	if gc.service == nil {
+		d := GetDefinition(c, IdentityId)
+		gc.service = &identity{d.Identifier().Name(), GetService(c, d.ServiceId())}
+		for _, cmd := range gc.deferredCommands {
+			cmd.apply(c, gc.service)
+		}
+		gc.deferredCommands = nil
+	}
+	return gc.service
+}
+
+func (gc *LazyIdentity) readOrNotFound(c px.Context, handler serviceapi.Service, hn string, extId px.Value) px.Value {
 	defer func() {
 		if r := recover(); r != nil {
 			if e, ok := r.(issue.Reported); ok {
 				if e, ok = e.Cause().(issue.Reported); ok && e.Code() == service.NotFound {
 					// Not found by remote. Purge the extId and return nil.
 					hclog.Default().Debug("Removing obsolete extId from Identity service", "extId", extId)
-					identity.purgeExternal(c, extId)
+					gc.getIdentity(c).purgeExternal(c, extId)
 					return
 				}
 			}
@@ -69,6 +133,19 @@ func readOrNotFound(c px.Context, handler serviceapi.Service, hn string, extId p
 	hclog.Default().Debug("Read state", "extId", extId)
 	return handler.Invoke(c, hn, `read`, extId)
 }
+
+func (gc *LazyIdentity) getExternal(c px.Context, internalId px.Value, required bool) px.Value {
+	return gc.getIdentity(c).getExternal(c, internalId, required)
+}
+
+func (gc *LazyIdentity) associate(c px.Context, internalID, externalID px.Value) {
+	gc.getIdentity(c).associate(c, internalID, externalID)
+}
+
+func (gc *LazyIdentity) removeExternal(c px.Context, externalID px.Value) {
+	gc.getIdentity(c).removeExternal(c, externalID)
+}
+
 func ApplyState(c px.Context, resource api.Resource, parameters px.OrderedMap) px.OrderedMap {
 	ac := StepContext(c)
 	op := GetOperation(ac)
@@ -76,7 +153,7 @@ func ApplyState(c px.Context, resource api.Resource, parameters px.OrderedMap) p
 	log := hclog.Default()
 	handlerDef := GetHandler(c, resource.HandlerId())
 	crd := GetProperty(handlerDef, `interface`, types.NewTypeType(types.DefaultObjectType())).(px.ObjectType)
-	identity := getIdentity(c)
+	identity := GetLazyIdentity(c)
 	handler := GetService(c, handlerDef.ServiceId())
 
 	intId := types.WrapString(resource.Identifier())
@@ -95,7 +172,7 @@ func ApplyState(c px.Context, resource api.Resource, parameters px.OrderedMap) p
 		if extId == nil {
 			return px.EmptyMap
 		}
-		rt := readOrNotFound(c, handler, hn, extId, identity)
+		rt := identity.readOrNotFound(c, handler, hn, extId)
 		if rt == nil {
 			return px.EmptyMap
 		}
@@ -105,7 +182,7 @@ func ApplyState(c px.Context, resource api.Resource, parameters px.OrderedMap) p
 		if explicitExtId {
 			// An explicit externalId is for resources not managed by us. Only possible action
 			// here is a read
-			rt := readOrNotFound(c, handler, hn, extId, identity)
+			rt := identity.readOrNotFound(c, handler, hn, extId)
 			if rt == nil {
 				// False positive from the Identity service
 				return px.EmptyMap
@@ -117,7 +194,7 @@ func ApplyState(c px.Context, resource api.Resource, parameters px.OrderedMap) p
 		desiredState := GetService(c, resource.ServiceId()).State(c, resource.Name(), parameters)
 		if extId != nil {
 			// Read current state and check if an update is needed
-			rt := readOrNotFound(c, handler, hn, extId, identity)
+			rt := identity.readOrNotFound(c, handler, hn, extId)
 			if rt == nil {
 				// False positive from the Identity service
 				extId = nil
@@ -157,7 +234,7 @@ func ApplyState(c px.Context, resource api.Resource, parameters px.OrderedMap) p
 				}
 			}
 
-			// Rely on that deletion happens by means of GC at end of run
+			// Rely on that deletion happens by means of LazyIdentity at end of run
 			log.Debug("Remove external", "extId", extId)
 			identity.removeExternal(c, extId)
 

--- a/service/identity.go
+++ b/service/identity.go
@@ -84,8 +84,3 @@ func (i *identity) removeInternal(c px.Context, internalID px.Value) {
 */
 
 var IdentityId = px.NewTypedName(px.NsDefinition, "Identity::Service")
-
-func getIdentity(c px.Context) *identity {
-	d := GetDefinition(c, IdentityId)
-	return &identity{d.Identifier().Name(), GetService(c, d.ServiceId())}
-}


### PR DESCRIPTION
This commit adds a LazyIdentity type. This type can be obtained and
used to initialize and perform a GC mark/sweep in a lazy fashion, i.e.
no identity service will be created unless there's been some other
activity related to it.

The reason this is needed is that it's very unnecessary to start the
identity service unless an apply of the the workflow involves at least
one resource step.