### PR TITLE
Ensure that call to a remote step is registered as reference

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/lyraproj/servicesdk v0.0.0-20190607070716-322c167d24a9
 	gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485
 )
+
+replace github.com/lyraproj/servicesdk => github.com/thallgren/servicesdk v0.0.0-20190614075654-f02c272830a4

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,6 @@ github.com/lyraproj/pcore v0.0.0-20190606102217-7824aee25201 h1:KlTHcsEPuRXi/cXY
 github.com/lyraproj/pcore v0.0.0-20190606102217-7824aee25201/go.mod h1:yqZNNXXw/2It5Jh2Vc+g93Qm+1q6EklXJ0t/xqNNBV8=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
-github.com/lyraproj/servicesdk v0.0.0-20190607070716-322c167d24a9 h1:u+JH8zmUaeXBjHnoc4YZz4MFOQwdClUuy7MXfX831f4=
-github.com/lyraproj/servicesdk v0.0.0-20190607070716-322c167d24a9/go.mod h1:+IR74NuJQyJnnRUUrtp44Lu5Iu950oAwW0oSs2isvXI=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 h1:7GoSOOW2jpsfkntVKaS2rAr1TJqfcxotyaUcuxoZSzg=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
@@ -37,6 +35,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/thallgren/servicesdk v0.0.0-20190614075654-f02c272830a4 h1:PUnK7tgP7c+rnY4Ct4vojNZtwLOaBYQV8TWvHNw2zco=
+github.com/thallgren/servicesdk v0.0.0-20190614075654-f02c272830a4/go.mod h1:+IR74NuJQyJnnRUUrtp44Lu5Iu950oAwW0oSs2isvXI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2 h1:y102fOLFqhV41b+4GPiJoa0k/x+pJcEi2/HB1Y5T6fU=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/service/identity.go
+++ b/service/identity.go
@@ -17,6 +17,10 @@ func (i *identity) associate(c px.Context, internalID, externalID px.Value) {
 	i.invokable.Invoke(c, i.id, `associate`, internalID, externalID)
 }
 
+func (i *identity) addReference(c px.Context, internalID, otherID px.Value) {
+	i.invokable.Invoke(c, i.id, `addReference`, internalID, otherID)
+}
+
 func (i *identity) bumpEra(c px.Context) {
 	i.invokable.Invoke(c, i.id, `bumpEra`)
 }
@@ -46,6 +50,10 @@ func (i *identity) sweep(c px.Context, prefix string) {
 
 func (i *identity) purgeExternal(c px.Context, externalID px.Value) {
 	i.invokable.Invoke(c, i.id, `purgeExternal`, externalID)
+}
+
+func (i *identity) purgeReferences(c px.Context, prefix string) {
+	i.invokable.Invoke(c, i.id, `purgeReferences`, types.WrapString(prefix))
 }
 
 func (i *identity) removeExternal(c px.Context, externalID px.Value) {

--- a/wfe/call.go
+++ b/wfe/call.go
@@ -63,6 +63,7 @@ func (r *call) When() wf.Condition {
 }
 
 func (r *call) Run(ctx px.Context, input px.OrderedMap) px.OrderedMap {
+	service.GetLazyIdentity(ctx).AddReference(ctx, r.Identifier(), r.ra.Identifier())
 	return r.mapOutput(r.ra.Run(ctx, r.mapInput(ResolveParameters(ctx, r, input))))
 }
 


### PR DESCRIPTION
This commit ensures that a call to a remote step is registered as a
reference in the identity store so that it gets properly traversed
during garbage collection.

Closes lyraproj/lyra#314