### PR TITLE
Use default resource annotation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ require (
 	github.com/hashicorp/go-hclog v0.8.0
 	github.com/lyraproj/issue v0.0.0-20190606092846-e082d6813d15
 	github.com/lyraproj/pcore v0.0.0-20190614121034-381c91502dac
-	github.com/lyraproj/servicesdk v0.0.0-20190614121348-74e5b88a139c
+	github.com/lyraproj/servicesdk v0.0.0-20190617121125-a22cb98187cb
 	gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485
 )

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/lyraproj/pcore v0.0.0-20190614121034-381c91502dac h1:K4cTDfI72xRV+i7y
 github.com/lyraproj/pcore v0.0.0-20190614121034-381c91502dac/go.mod h1:yqZNNXXw/2It5Jh2Vc+g93Qm+1q6EklXJ0t/xqNNBV8=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
-github.com/lyraproj/servicesdk v0.0.0-20190614121348-74e5b88a139c h1:XvNS2pW3wufmgP4OZA64fBmu0x0EoU5uJy2q6Tm36cY=
-github.com/lyraproj/servicesdk v0.0.0-20190614121348-74e5b88a139c/go.mod h1:1JW0P7jN4e9J8ujxBYaVTLVd5dK7bqlVC0VvTZspwr8=
+github.com/lyraproj/servicesdk v0.0.0-20190617121125-a22cb98187cb h1:tD7CAn75MziXKk9RNv1cHJYvxl9VxDmXD5iKaIwwsas=
+github.com/lyraproj/servicesdk v0.0.0-20190617121125-a22cb98187cb/go.mod h1:1JW0P7jN4e9J8ujxBYaVTLVd5dK7bqlVC0VvTZspwr8=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 h1:7GoSOOW2jpsfkntVKaS2rAr1TJqfcxotyaUcuxoZSzg=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=

--- a/service/crud.go
+++ b/service/crud.go
@@ -232,14 +232,14 @@ func ApplyState(c px.Context, resource api.Resource, parameters px.OrderedMap) p
 			break
 		}
 
-		var updateNeeded, recreateNeeded bool
+		var ra annotation.Resource
 		if a, ok := resource.Type().Annotations(c).Get(annotation.ResourceType); ok {
-			ra := a.(annotation.Resource)
-			updateNeeded, recreateNeeded = ra.Changed(c, desiredState, result)
+			ra = a.(annotation.Resource)
 		} else {
-			updateNeeded = !desiredState.Equals(result, nil)
-			recreateNeeded = false
+			log.Debug("Using default Resource annotation", "resource", resource.Type().Name())
+			ra = annotation.DefaultResource()
 		}
+		updateNeeded, recreateNeeded := ra.Changed(c, desiredState, result)
 
 		if updateNeeded {
 			if !recreateNeeded {


### PR DESCRIPTION
This commit ensures that the comparison between actual and desired state
is done using a resource annotation at all times to ensure that the same
codepath is used and all debug info is logged even when no annotation
exists for the given resource type.